### PR TITLE
Ensure use of full tags for compatibility.

### DIFF
--- a/src/views/sitemaps.php
+++ b/src/views/sitemaps.php
@@ -1,10 +1,10 @@
-<?= '<?xml version="1.0" encoding="UTF-8"?>' ?>
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>' ?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <?php foreach ($sitemaps as $sitemap): ?>
   <sitemap>
-    <loc><?= $sitemap->getLocation() ?></loc>
+    <loc><?php echo $sitemap->getLocation() ?></loc>
     <?php if ($sitemap->getLastModified()): ?>
-      <lastmod><?= $sitemap->getLastModified()->format('Y-m-d\TH:i:sP') ?></lastmod>
+      <lastmod><?php echo $sitemap->getLastModified()->format('Y-m-d\TH:i:sP') ?></lastmod>
     <?php endif; ?>
   </sitemap>
   <?php endforeach ?>


### PR DESCRIPTION
Not all environments have the option for short-hand tags turned on, better to use full syntax.