### PR TITLE
add multilangual urls to sitemap if array is added

### DIFF
--- a/src/Watson/Sitemap/Tags/Tag.php
+++ b/src/Watson/Sitemap/Tags/Tag.php
@@ -22,10 +22,11 @@ class Tag extends BaseTag
      * @var array
      */
     protected $xmlTags = [
-        'loc'        => 'location',
-        'lastmod'    => 'lastModified',
+        'loc' => 'location',
+        'lastmod' => 'lastModified',
         'changefreq' => 'changeFrequency',
-        'priority'   => 'priority'
+        'priority' => 'priority',
+        'xhtml:link' => 'Alternate',
     ];
 
     /**
@@ -37,12 +38,13 @@ class Tag extends BaseTag
      * @param  string  $priority
      * @return void
      */
-    public function __construct($location, $lastModified = null, $changeFrequency = null, $priority = null)
+    public function __construct($location, $lastModified = null, $changeFrequency = null, $priority = null, $multiLangual = null)
     {
         parent::__construct($location, $lastModified);
 
         $this->changeFrequency = $changeFrequency;
         $this->priority = $priority;
+        $this->multilang = $multiLangual;
     }
 
     /**
@@ -74,6 +76,16 @@ class Tag extends BaseTag
     public function getPriority()
     {
         return $this->priority;
+    }
+
+    /**
+     * Get the multilangual urls if exist.
+     *
+     * @return array
+     */
+    public function getMultiLangual()
+    {
+        return $this->multilang;
     }
 
     /**

--- a/src/views/sitemap.php
+++ b/src/views/sitemap.php
@@ -3,6 +3,7 @@
   xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xhtml="http://www.w3.org/TR/xhtml11/xhtml11_schema.html"
   xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
     http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <?php foreach ($tags as $tag): ?>
@@ -10,18 +11,23 @@
       <loc><?php echo $tag->getLocation() ?></loc>
       <?php if ($tag->getLastModified()): ?>
         <lastmod><?php echo $tag->getLastModified()->format('Y-m-d\TH:i:sP') ?></lastmod>
-      <?php endif ?>
+      <?php endif?>
       <?php if ($tag instanceof \Watson\Sitemap\Tags\Tag): ?>
+        <?php if ($tag->getMultiLangual()): ?>
+          <?php foreach ($tag->getMultiLangual() as $key => $value): ?>
+              <xhtml:link rel="alternate" hreflang="<?php echo $key ?>" href="<?php echo $value ?>"  />
+          <?php endforeach;?>
+        <?php endif?>
         <?php if ($tag->getPriority()): ?>
           <priority><?php echo $tag->getPriority() ?></priority>
-        <?php endif ?>
+        <?php endif?>
         <?php if ($tag->getChangeFrequency()): ?>
           <changefreq><?php echo $tag->getChangeFrequency() ?></changefreq>
-        <?php endif ?>
-      <?php endif; ?>
+        <?php endif?>
+      <?php endif;?>
       <?php if ($tag instanceof \Watson\Sitemap\Tags\ExpiredTag): ?>
         <expires><?php echo $tag->getExpired()->format('Y-m-d\TH:i:sP') ?></expires>
-      <?php endif; ?>
+      <?php endif;?>
     </url>
-  <?php endforeach ?>
+  <?php endforeach?>
 </urlset>


### PR DESCRIPTION
- regular xmlns:xtml at line 6 would return string sitemap as a string, this returns it as the xml sitemap, trust me I tried;
- when you add after priority an extra array parameter with as key the language and value the url it will render correctly.

for example:
`[
'nl'=>'example.com/dutch-path/',
'en=>'example.com/english-path/',
'fr'=>'example.com/french-path/',
]`

it will render before `<priority>whatever</priority>` as
`<xhtml:link rel="alternate" hreflang="nl" href="example.com/dutch-path/"/>
<xhtml:link rel="alternate" hreflang="en" href="example.com/english-path/"/>
<xhtml:link rel="alternate" hreflang="fr" href="example.com/french-path/"/>`