### PR TITLE
Allow Upgrade to Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "watson/sitemap",
-    "description": "Generate Google Sitemaps in Laravel 4/5",
+    "description": "Generate Google Sitemaps in Laravel 4/5/6",
     "keywords": ["laravel", "sitemaps"],
     "license": "MIT",
     "authors": [
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/http": "~5.0",
-        "illuminate/support": "~5.0"
+        "illuminate/http": "~5.0|^6.0",
+        "illuminate/support": "~5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*",

--- a/src/Watson/Sitemap/Sitemap.php
+++ b/src/Watson/Sitemap/Sitemap.php
@@ -1,6 +1,7 @@
 <?php namespace Watson\Sitemap;
 
 use DateTime;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Watson\Sitemap\Tags\Tag;
 use Illuminate\Http\Response;
@@ -337,6 +338,6 @@ class Sitemap
      */
     protected function getCacheKey()
     {
-        return 'sitemap_' . str_slug($this->request->url());
+        return 'sitemap_' . Str::slug($this->request->url());
     }
 }


### PR DESCRIPTION
it may be time to break off a new version for Laravel 6 and forward, and bump that PHP version requirement.

If you don't feel that's necessary, here's a PR to get this working with Laravel 6.