### PR TITLE
Support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 | ^8.0",
         "illuminate/http": "^8.0",
         "illuminate/support": "^8.0"
     },


### PR DESCRIPTION
Seems to work fine with PHP8, you  just needed the `^ 8.0` in the _composer.json_.

```
./vendor/bin/phpunit
PHPUnit 9.4.3 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Line 18:
  - Element 'filter': This element is not expected.

  Test results may not be as expected.


..R..R...........................................                 49 / 49 (100%)

Time: 00:00.087, Memory: 8.00 MB

There were 2 risky tests:

1) SitemapTest::test_renders_sitemaps
This test did not perform any assertions

/xxx/sitemap/tests/SitemapTest.php:44

2) SitemapTest::test_render_sitemap
This test did not perform any assertions

/xxx/sitemap/tests/SitemapTest.php:65

OK, but incomplete, skipped, or risky tests!
Tests: 49, Assertions: 79, Risky: 2.
```