### PR TITLE
Fix docblocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.phpunit.result.cache

--- a/src/Watson/Sitemap/Sitemap.php
+++ b/src/Watson/Sitemap/Sitemap.php
@@ -2,8 +2,10 @@
 
 namespace Watson\Sitemap;
 
+use DateTimeInterface;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Watson\Sitemap\Tags\BaseTag;
 use Watson\Sitemap\Tags\Tag;
 use Illuminate\Http\Response;
 use Watson\Sitemap\Tags\ExpiredTag;
@@ -16,14 +18,14 @@ class Sitemap
     /**
      * Collection of sitemaps being used.
      *
-     * @var array
+     * @var SitemapTag[]
      */
     protected $sitemaps = [];
 
     /**
      * Collection of tags being used in a sitemap.
      *
-     * @var array
+     * @var (Tag|ExpiredTag)[]
      */
     protected $tags = [];
 
@@ -58,7 +60,7 @@ class Sitemap
      * Add new sitemap to the sitemaps index.
      *
      * @param  \Watson\Sitemap\Tags\Sitemap|string  $location
-     * @param  \DateTime|string  $lastModified
+     * @param  \DateTimeInterface|string|null  $lastModified
      * @return void
      */
     public function addSitemap($location, $lastModified = null)
@@ -71,7 +73,7 @@ class Sitemap
     /**
      * Retrieve the array of sitemaps.
      *
-     * @return array
+     * @return SitemapTag[]
      */
     public function getSitemaps()
     {
@@ -110,9 +112,9 @@ class Sitemap
      * Add a new sitemap tag to the sitemap.
      *
      * @param  \Watson\Sitemap\Tags\Tag|string  $location
-     * @param  \DateTime|string  $lastModified
-     * @param  string  $changeFrequency
-     * @param  string  $priority
+     * @param  \DateTimeInterface|string|null  $lastModified
+     * @param  string|null  $changeFrequency
+     * @param  string|null  $priority
      * @return \Watson\Sitemap\Tags\Tag
      */
     public function addTag($location, $lastModified = null, $changeFrequency = null, $priority = null)
@@ -128,7 +130,7 @@ class Sitemap
      * Add a new expired tag to the sitemap.
      *
      * @param  string  $location
-     * @param  \DateTime|string  $expired
+     * @param  \DateTimeInterface|string|null  $expired
      * @return void
      */
     public function addExpiredTag($location, $expired = null)
@@ -141,7 +143,7 @@ class Sitemap
     /**
      * Retrieve the array of tags.
      *
-     * @return array
+     * @return BaseTag[]
      */
     public function getTags()
     {

--- a/src/Watson/Sitemap/Tags/BaseTag.php
+++ b/src/Watson/Sitemap/Tags/BaseTag.php
@@ -4,6 +4,7 @@ namespace Watson\Sitemap\Tags;
 
 use DateTime;
 use ArrayAccess;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Watson\Sitemap\Tags\Video\VideoTag;
 
@@ -19,7 +20,7 @@ abstract class BaseTag implements ArrayAccess
     /**
      * The last modified timestamp.
      *
-     * @var \DateTime
+     * @var \DateTimeInterface|null
      */
     protected $lastModified;
 
@@ -51,7 +52,7 @@ abstract class BaseTag implements ArrayAccess
      * Construct the tag.
      *
      * @param  string  $location
-     * @param  \DateTime|string  $lastModified
+     * @param  \DateTimeInterface|string|null  $lastModified
      * @return void
      */
     public function __construct($location, $lastModified = null)
@@ -87,7 +88,7 @@ abstract class BaseTag implements ArrayAccess
     /**
      * Get the last modified timestamp.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface|null
      */
     public function getLastModified()
     {
@@ -97,12 +98,12 @@ abstract class BaseTag implements ArrayAccess
     /**
      * Set the last modified timestamp.
      *
-     * @param  \DateTime|string  $lastModified
+     * @param  \DateTimeInterface|\Illuminate\Database\Eloquent\Model|string  $lastModified
      * @return void
      */
     public function setLastModified($lastModified)
     {
-        if ($lastModified instanceof DateTime) {
+        if ($lastModified instanceof DateTimeInterface) {
             $this->lastModified = $lastModified;
             return;
         } elseif ($lastModified instanceof Model) {

--- a/src/Watson/Sitemap/Tags/BaseTag.php
+++ b/src/Watson/Sitemap/Tags/BaseTag.php
@@ -4,7 +4,6 @@ namespace Watson\Sitemap\Tags;
 
 use DateTime;
 use ArrayAccess;
-use Watson\Sitemap\Tags\ImageTag;
 use Illuminate\Database\Eloquent\Model;
 use Watson\Sitemap\Tags\Video\VideoTag;
 
@@ -27,14 +26,14 @@ abstract class BaseTag implements ArrayAccess
     /**
      * Image tags belonging to this tag.
      *
-     * @var array
+     * @var ImageTag[]
      */
     protected $images = [];
 
     /**
      * Videos tags belonging to this tag.
      *
-     * @var array
+     * @var VideoTag[]
      */
     protected $videos = [];
 
@@ -117,11 +116,11 @@ abstract class BaseTag implements ArrayAccess
     /**
      * Add an image tag to the tag.
      *
-     * @param  string  $location
-     * @param  string  $caption
-     * @param  string  $geo_location
-     * @param  string  $title
-     * @param  string  $license
+     * @param  string|ImageTag  $location
+     * @param  string|null  $caption
+     * @param  string|null  $geoLocation
+     * @param  string|null  $title
+     * @param  string|null  $license
      * @return void
      */
     public function addImage($location, $caption = null, $geoLocation = null, $title = null, $license = null)
@@ -134,10 +133,10 @@ abstract class BaseTag implements ArrayAccess
     /**
      * Add a video tag to the tag.
      *
-     * @param  string  $location
-     * @param  string  $title
-     * @param  string  $description
-     * @param  string  $thumbnailLocation
+     * @param  string|VideoTag  $location
+     * @param  string|null  $title
+     * @param  string|null  $description
+     * @param  string|null  $thumbnailLocation
      * @return void
      */
     public function addVideo($location, $title = null, $description = null, $thumbnailLocation = null)

--- a/src/Watson/Sitemap/Tags/ExpiredTag.php
+++ b/src/Watson/Sitemap/Tags/ExpiredTag.php
@@ -3,6 +3,7 @@
 namespace Watson\Sitemap\Tags;
 
 use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 
 class ExpiredTag extends BaseTag
@@ -10,7 +11,7 @@ class ExpiredTag extends BaseTag
     /**
      * The expiration date.
      *
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $expired;
 
@@ -28,7 +29,7 @@ class ExpiredTag extends BaseTag
      * Construct the tag.
      *
      * @param  string  $location
-     * @param  \DateTime|string  $expired
+     * @param  \DateTimeInterface|string|null  $expired
      * @return void
      */
     public function __construct($location, $expired = null)
@@ -41,7 +42,7 @@ class ExpiredTag extends BaseTag
     /**
      * Get the expired timestamp.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getExpired()
     {
@@ -51,12 +52,12 @@ class ExpiredTag extends BaseTag
     /**
      * Set the expiration date
      *
-     * @param  \DateTime|string  $expired
+     * @param  \DateTimeInterface|\Illuminate\Database\Eloquent\Model|string  $expired
      * @return void
      */
     public function setExpired($expired)
     {
-        if ($expired instanceof DateTime) {
+        if ($expired instanceof DateTimeInterface) {
             $this->expired = $expired;
             return;
         } elseif ($expired instanceof Model) {

--- a/src/Watson/Sitemap/Tags/ImageTag.php
+++ b/src/Watson/Sitemap/Tags/ImageTag.php
@@ -7,28 +7,28 @@ class ImageTag extends BaseTag
     /**
      * The caption of the image.
      *
-     * @var string
+     * @var string|null
      */
     protected $caption;
 
     /**
      * The geographic location of the image.
      *
-     * @var string
+     * @var string|null
      */
     protected $geoLocation;
 
     /**
      * The title of the image.
      *
-     * @var string
+     * @var string|null
      */
     protected $title;
 
     /**
      * A URL to the license of the image.
      *
-     * @var string
+     * @var string|null
      */
     protected $license;
 
@@ -49,10 +49,10 @@ class ImageTag extends BaseTag
      * Construct the tag.
      *
      * @param  string  $location
-     * @param  string  $caption
-     * @param  string  $geo_location
-     * @param  string  $title
-     * @param  string  $license
+     * @param  string|null  $caption
+     * @param  string|null  $geoLocation
+     * @param  string|null  $title
+     * @param  string|null  $license
      * @return void
      */
     public function __construct($location, $caption = null, $geoLocation = null, $title = null, $license = null)
@@ -68,7 +68,7 @@ class ImageTag extends BaseTag
     /**
      * Get the caption.
      *
-     * @return string
+     * @return string|null
      */
     public function getCaption()
     {
@@ -89,7 +89,7 @@ class ImageTag extends BaseTag
     /**
      * Get the geoLocation.
      *
-     * @return string
+     * @return string|null
      */
     public function getGeoLocation()
     {
@@ -110,7 +110,7 @@ class ImageTag extends BaseTag
     /**
      * Get the title.
      *
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
@@ -131,7 +131,7 @@ class ImageTag extends BaseTag
     /**
      * Get the license.
      *
-     * @return string
+     * @return string|null
      */
     public function getLicense()
     {

--- a/src/Watson/Sitemap/Tags/MultilingualTag.php
+++ b/src/Watson/Sitemap/Tags/MultilingualTag.php
@@ -28,9 +28,9 @@ class MultilingualTag extends Tag
      * Construct the tag.
      *
      * @param  string  $location
-     * @param  string  $lastModified
-     * @param  string  $changeFrequency
-     * @param  string  $priority
+     * @param  string|null  $lastModified
+     * @param  string|null  $changeFrequency
+     * @param  string|null  $priority
      * @param  array   $multilingual
      * @return void
      */

--- a/src/Watson/Sitemap/Tags/Tag.php
+++ b/src/Watson/Sitemap/Tags/Tag.php
@@ -7,14 +7,14 @@ class Tag extends BaseTag
     /**
      * The change frequency.
      *
-     * @var string
+     * @var string|null
      */
     protected $changeFrequency;
 
     /**
      * The priority.
      *
-     * @var string
+     * @var string|null
      */
     protected $priority;
 
@@ -34,9 +34,9 @@ class Tag extends BaseTag
      * Construct the tag.
      *
      * @param  string  $location
-     * @param  string  $lastModified
-     * @param  string  $changeFrequency
-     * @param  string  $priority
+     * @param  \DateTimeInterface|string|null  $lastModified
+     * @param  string|null  $changeFrequency
+     * @param  string|null  $priority
      * @return void
      */
     public function __construct($location, $lastModified = null, $changeFrequency = null, $priority = null)
@@ -50,7 +50,7 @@ class Tag extends BaseTag
     /**
      * Get the change frequency.
      *
-     * @return string
+     * @return string|null
      */
     public function getChangeFrequency()
     {
@@ -71,7 +71,7 @@ class Tag extends BaseTag
     /**
      * Get the priority.
      *
-     * @return string
+     * @return string|null
      */
     public function getPriority()
     {

--- a/src/Watson/Sitemap/Tags/Video/VideoTag.php
+++ b/src/Watson/Sitemap/Tags/Video/VideoTag.php
@@ -2,7 +2,7 @@
 
 namespace Watson\Sitemap\Tags\Video;
 
-use DateTime;
+use DateTimeInterface;
 use Watson\Sitemap\Tags\BaseTag;
 
 class VideoTag extends BaseTag
@@ -52,7 +52,7 @@ class VideoTag extends BaseTag
     /**
      * The tag expiration date.
      *
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $expirationDate;
 
@@ -73,7 +73,7 @@ class VideoTag extends BaseTag
     /**
      * The tag publication date.
      *
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $publicationDate;
 
@@ -240,7 +240,7 @@ class VideoTag extends BaseTag
     /**
      * Get the video duration.
      *
-     * @var int
+     * @return int
      */
     public function getDuration()
     {
@@ -261,7 +261,7 @@ class VideoTag extends BaseTag
     /**
      * Get the expiration date.
      *
-     * @var \DateTime
+     * @return \DateTimeInterface
      */
     public function getExpirationDate()
     {
@@ -271,10 +271,10 @@ class VideoTag extends BaseTag
     /**
      * Set the expiration date.
      *
-     * @param  \DateTime  $expirationDate
+     * @param  \DateTimeInterface  $expirationDate
      * @return void
      */
-    public function setExpirationDate(DateTime $expirationDate)
+    public function setExpirationDate(DateTimeInterface $expirationDate)
     {
         $this->expirationDate = $expirationDate;
     }
@@ -324,7 +324,7 @@ class VideoTag extends BaseTag
     /**
      * Get the publication date.
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getPublicationDate()
     {
@@ -334,10 +334,10 @@ class VideoTag extends BaseTag
     /**
      * Set the publication date.
      *
-     * @param  \DateTime  $publicationDate
+     * @param  \DateTimeInterface  $publicationDate
      * @return void
      */
-    public function setPublicationDate(DateTime $publicationDate)
+    public function setPublicationDate(DateTimeInterface $publicationDate)
     {
         $this->publicationDate = $publicationDate;
     }


### PR DESCRIPTION
The docblocks for `addImage()` and `addVideo()` do not allow for receiving instances. This results in PHPStan errors like 
```
 - '#Parameter \#1 \$location of method Watson\\Sitemap\\Tags\\BaseTag\:\:addVideo\(\) expects string, Watson\\Sitemap\\Tags\\Video\\VideoTag given#'
  🪪 argument.type
```