### PR TITLE
Fix param name of getXmlTagAttribute

### DIFF
--- a/src/Watson/Sitemap/Tags/BaseTag.php
+++ b/src/Watson/Sitemap/Tags/BaseTag.php
@@ -228,7 +228,7 @@ abstract class BaseTag implements ArrayAccess
         return null;
     }
 
-    protected function getXmlTagAttribute($tag)
+    protected function getXmlTagAttribute($offset)
     {
         if (array_key_exists($offset, $this->xmlTags)) {
             return $this->xmlTags[$offset];


### PR DESCRIPTION
`getXmlTagAttribute` received a param called `$tag` while the implementation uses `$offset` which is currently undefined. This change fixed that issue. 